### PR TITLE
support remember user-preferred language

### DIFF
--- a/components/language-select.tsx
+++ b/components/language-select.tsx
@@ -75,6 +75,7 @@ const LanguageSelect: FunctionComponent<Props> = ({ className }) => {
             { locale: localeValue, scroll: false }
           );
       }
+      document.cookie = `NEXT_LOCALE=${localeValue};max-age=2147483647`;
     })();
   }, [localeValue]);
 


### PR DESCRIPTION
This pull request allows '/' redirects to the last selected language.

Chinese version of documentation is in some way outdated.
Some developers like me need to switch language every time they open the homepage.