### PR TITLE
drop trailing slash from canonical urls

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -9,6 +9,7 @@ import vercelRedirects from "./src/integrations/vercel-redirects";
 export default defineConfig({
   site: "https://bedrock.dev",
   output: "static",
+  trailingSlash: "never",
   prefetch: true,
   integrations: [react(), vercelRedirects()],
   adapter: vercel(),


### PR DESCRIPTION
Astro's default `directory` build format made `Astro.url.pathname` end in a slash, so every canonical pointed at a URL the site doesn't publish.